### PR TITLE
Nodes show edge relationships even when unselected

### DIFF
--- a/components/Column.js
+++ b/components/Column.js
@@ -1,14 +1,27 @@
-import { Handle } from 'react-flow-renderer';
-import { useState } from 'react';
+import { Handle, useStoreState } from 'react-flow-renderer';
+import { useState, useEffect } from 'react';
 
 const Column = (props) => {
 
+    const store = useStoreState((store) => store);
     const [active, selectColumn] = useState(false);
+    const [activeEdges, populateEdges] = useState([]);
+
+    useEffect(() => {
+        
+        if (!store.selectedElements)
+            return;
+
+        populateEdges(props.selectedEdges([store.selectedElements[0]], store.edges));
+        
+    }, [store.selectedElements]);
 
     const alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
     const targetBackground = () => {
-        if (props.edges.some(edge => edge.targetHandle === alphabet[props.index] && edge.target == props.nodeid.toString()) && props.expanded)
+        if (props.edges.some(edge => edge.targetHandle === alphabet[props.index]
+            && edge.target == props.nodeid.toString())
+            && props.expanded && props.selected)
             return '#ff6b6b';
         if (props.selected && props.expanded && active)
             return '#f1f6f8';
@@ -16,11 +29,48 @@ const Column = (props) => {
     }
 
     const sourceBackground = () => {
-        if (props.edges.some(edge => edge.sourceHandle === alphabet[props.index] && edge.source === props.nodeid.toString()) && props.expanded)
+        if (props.edges.some(edge => edge.sourceHandle === alphabet[props.index]
+            && edge.source === props.nodeid.toString())
+            && props.expanded && props.selected)
             return '#0373fc';
         if (props.selected && props.expanded && active)
             return '#f1f6f8';
         return 'transparent';
+    }
+
+    const targetBorder = () => {
+        if (props.edges.some(edge => edge.targetHandle === alphabet[props.index]
+            && edge.target == props.nodeid.toString())
+            && activeEdges.some(edge => edge.targetHandle === alphabet[props.index]
+            && edge.target === props.nodeid.toString())
+            && props.expanded && !props.selected){
+            return '5px solid #ff6b6b';
+        }
+        if (props.selected && active && props.expanded)
+            return '5px solid #0373fc';
+        if (props.selected && !active && props.expanded)
+            return '5px solid transparent';
+        if (props.expanded && active)
+            return '5px solid #0373fc';
+        return '5px solid transparent';
+    }
+
+    const sourceBorder = () => {
+        if (props.edges.some(edge => edge.sourceHandle === alphabet[props.index]
+            && edge.source === props.nodeid.toString())
+            && activeEdges.some(edge => edge.sourceHandle === alphabet[props.index]
+            && edge.source === props.nodeid.toString())
+            && props.expanded && !props.selected){
+            return '5px solid #0373fc';
+        }
+        if (props.selected && active && props.expanded)
+            return '5px solid #0373fc';
+        if (props.selected && !active && props.expanded)
+            return '5px solid transparent';
+        if (props.expanded && active)
+            return '5px solid #0373fc';
+        return '5px solid transparent';
+
     }
 
     const borderColor = () => {
@@ -68,7 +118,7 @@ const Column = (props) => {
                         float: 'left',
                         left: `${targetPos()}`,
                         width: `32px`, height: `32px`,
-                        border: `${borderColor()}`,
+                        border: `${targetBorder()}`,
                         backgroundColor: `${targetBackground()}`
                     }}
                 
@@ -92,7 +142,7 @@ const Column = (props) => {
                         float: 'right',
                         left: `${sourcePos()}`,
                         width: `32px`, height: `32px`,
-                        border: `${borderColor()}`,
+                        border: `${sourceBorder()}`,
                         backgroundColor: `${sourceBackground()}`
                     }}
 

--- a/components/Node.js
+++ b/components/Node.js
@@ -18,7 +18,13 @@ export default memo(({ data }) => {
     //An array storing all in-going and out-going edges
     const [edges, populateEdges] = useState([]);
 
-    //useEffect #1 on [selectedElements]:
+    //useEffect #1 on [store.edges]:
+    //Populate the edges array on first render, and every time our edges change
+    useEffect(() => {
+        populateEdges(props.selectedEdges([store.elements[props.nodeid]], store.edges));
+    }, [store.edges]);
+
+    //useEffect #2 on [selectedElements]:
     //Checks the selectedElement's id against this node's id
     //If they match, this becomes the selected node.
     useEffect(() => {
@@ -34,33 +40,30 @@ export default memo(({ data }) => {
             selectNode(true);
             showTable(true);
 
-            populateEdges(props.selectedEdges([store.selectedElements[0]], store.edges))
-
         }
         else if (store.selectedElements[0].id !== props.nodeid.toString() && selected){
             
+            selectNode(false);
+
             edges.forEach(edge => {
                 edge.style = { stroke: 'rgba(3, 115, 252, .75)', strokeWidth: '1px' };
             });
-
-            selectNode(false);
-            populateEdges([]);
 
         }
 
     }, [store.selectedElements]);
 
-    //useEffect #2 on [edges]:
+    //useEffect #3 on [edges]:
     //Checks for changes in the edges state array length
     //When the array becomes greater than 0, we highlight the edges and color in-going and out-going
     useEffect(() => {
 
-        if (!edges.length)
+        if (!selected)
             return;
 
         edges.forEach(edge => edge.source === props.nodeid.toString() ? edge.style = { stroke: 'rgba(3, 115, 252, 1)', strokeWidth: '5px' } : edge.style = { stroke: 'rgba(255, 107, 107, 1)', strokeWidth: '5px' });
 
-    }, [edges])
+    }, [selected])
 
     //Array of possible header colors
     //TOOD: Expand, make editable
@@ -77,7 +80,7 @@ export default memo(({ data }) => {
             </div>
             
             <div className='tables' style={{maxHeight: `${expand ? '4000px' : '0px'}`, overflowY: `${expand ? 'visible' : 'hidden'}`, transition: `${!  expand ? 'all .6s ease' : 'all 0.6s ease'}`}} >
-                {props.columns.map((column, i) => <Column name={column.name} id={`${column.name}#${i}`} key={`${column.name}#${i}`} nodeid={props.nodeid} index={i} dataType={column.dataType} edges={edges} expanded={expand} selected={selected} />)}
+                {props.columns.map((column, i) => <Column name={column.name} id={`${column.name}#${i}`} key={`${column.name}#${i}`} nodeid={props.nodeid} index={i} dataType={column.dataType} edges={edges} expanded={expand} selected={selected} selectedEdges={props.selectedEdges} />)}
             </div>
 
             <div className='nodecontainer' />

--- a/controller/controller.js
+++ b/controller/controller.js
@@ -18,7 +18,7 @@ module.exports = {
     return new Promise((resolve) => {
       pool.query(query, params, (err, data) => {
         if (err) return resolve(new Error(err));
-        else return resolve(data);
+        else return (console.log('oops i did it again'), resolve(data));
       })
     })
   },


### PR DESCRIPTION
**Issue:**
Hard for user to identify where nodes connected beyond the scope of the activeNode.

**Solution:**
All node column's now hold a reference to both their connected edges as well as the activeNode's edges, and compare values to visualize relationships.