### PR TITLE
GraphQL converter creates types for each table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+exampledata.json
+
 # dependencies
 /node_modules
 /.pnp

--- a/converters/TypeDefs.js
+++ b/converters/TypeDefs.js
@@ -1,0 +1,29 @@
+const { plural, singular } = require('pluralize');
+const { convertDataType, capitalizeFirstLetter } = require('./helpers.js');
+
+//turn table database into GraphQL format schema
+function tableToType(table) {
+    let upperCaseL = capitalizeFirstLetter(table.name);
+    let type = `type ${singular(upperCaseL)} { \n`;
+
+    table.columns.forEach((col) => {
+      type += ' ' + mapColumn(col) + '\n';
+    })
+    type += '}'
+    return type;
+}
+
+//turn a single column object into a line in the GraphQL object type
+function mapColumn(column) {
+  let str = `${column.name}: ${convertDataType(column.dataType)}`;
+  if (column.required) str += '!';
+  return str;
+}
+
+function generateAllTypes(tables) {
+  let allTypes = ``;
+  tables.forEach((table) => {
+    allTypes += tableToType(table) + '\n\n';
+  });
+  return allTypes;
+}

--- a/converters/TypeDefs.js
+++ b/converters/TypeDefs.js
@@ -1,6 +1,8 @@
 const { plural, singular } = require('pluralize');
 const { convertDataType, capitalizeFirstLetter } = require('./helpers.js');
 
+const exampleData = require('../exampledata.json');
+
 //turn table database into GraphQL format schema
 function tableToType(table) {
     let upperCaseL = capitalizeFirstLetter(table.name);
@@ -27,3 +29,5 @@ function generateAllTypes(tables) {
   });
   return allTypes;
 }
+
+module.exports = generateAllTypes;

--- a/converters/helpers.js
+++ b/converters/helpers.js
@@ -1,0 +1,22 @@
+//All helper function for converters
+module.exports = {
+  convertDataType: (sqlDataType) => {
+    switch (sqlDataType) {
+    case 'character varying':
+      return 'String';
+    case 'integer':
+      return 'Int';
+    case 'bigint':
+      return 'Int';
+    case 'date':
+      return 'Int';
+    default:
+      return 'Unknown';
+    }
+  },
+
+  capitalizeFirstLetter: (string) => {
+    return string[0].toUpperCase() + string.slice(1);
+  }
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,6 +3624,11 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
+    },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "electron": "^11.2.1",
     "next": "^10.0.6",
     "pg": "^8.5.1",
+    "pluralize": "^8.0.0",
     "react": "^17.0.1",
     "react-dom": "17.0.1",
     "react-flow-renderer": "^8.7.0",


### PR DESCRIPTION
**Issue:** We need to generate GraphQL schema code base on data from postgresql. 

**Changes in this PR:** 
- For each table return from the scrapedb endpoint, create a new Type with a line for each column, specifying the datatype and if it's a required filed 
- Added helper functions to convert SQL datatypes to GraphQL datatypes as well as capitalize the first letter of a word 
- Installed pluralize library 