### PR TITLE
Added logic to include foreign key relationships to TypeDefs

### DIFF
--- a/converters/TypeDefs.js
+++ b/converters/TypeDefs.js
@@ -1,10 +1,9 @@
 const { plural, singular } = require('pluralize');
 const { 
   convertDataType, 
-  capitalizeFirstLetter, 
-  findJoinTables,
-  mapJoinConnections,
-  sortTables
+  capitalizeFirstLetter,
+  sortTables,
+  joinConnections
 } = require('./helpers.js');
 
 const exampleData = require('../exampledata.json');
@@ -52,12 +51,8 @@ function mapConnection(connection) {
 function generateAllTypes(tables) {
   let allTypes = `TypeDefs = \` \n`;
   const [baseTables, joinTables] = sortTables(tables);
-  const joinTables = findJoinTables(tables);
-  const tablesToType = tables.filter((table) => {
-    return !Object.keys(joinTables).includes(table.name)
-  });
-  const allJoinConnections = mapJoinConnections(joinTables);
-  tablesToType.forEach((table) => {
+  const allJoinConnections = joinConnections(joinTables);
+  baseTables.forEach((table) => {
     allTypes += tableToType(table, allJoinConnections[table.name]) + '\n\n';
   });
   return allTypes + `\``;

--- a/converters/TypeDefs.js
+++ b/converters/TypeDefs.js
@@ -6,8 +6,6 @@ const {
   joinConnections
 } = require('./helpers.js');
 
-const exampleData = require('../exampledata.json');
-
 //turn table database into GraphQL format schema
 function tableToType(table, joinConnections) {
     let upperCaseL = capitalizeFirstLetter(table.name);

--- a/converters/TypeDefs.js
+++ b/converters/TypeDefs.js
@@ -1,33 +1,66 @@
 const { plural, singular } = require('pluralize');
-const { convertDataType, capitalizeFirstLetter } = require('./helpers.js');
+const { 
+  convertDataType, 
+  capitalizeFirstLetter, 
+  findJoinTables,
+  mapJoinConnections,
+  sortTables
+} = require('./helpers.js');
 
-// const exampleData = require('../exampledata.json');
+const exampleData = require('../exampledata.json');
 
 //turn table database into GraphQL format schema
-function tableToType(table) {
+function tableToType(table, joinConnections) {
     let upperCaseL = capitalizeFirstLetter(table.name);
     let type = `type ${singular(upperCaseL)} { \n`;
 
     table.columns.forEach((col) => {
       type += ' ' + mapColumn(col) + '\n';
     })
+
+    if (table.connections.length) {
+      table.connections.forEach((conn) => {
+        type += ' ' + mapConnection(conn.destinationTable) + '\n';
+      })
+    }
+
+    if (joinConnections) {
+      joinConnections.forEach((jc) => {
+        type += ` ${mapConnection(jc)}\n`;
+      })
+    }
+
     type += '}'
     return type;
 }
 
-//turn a single column object into a line in the GraphQL object type
+//turn a single column object into a line in the GraphQL object definition
 function mapColumn(column) {
   let str = `${column.name}: ${convertDataType(column.dataType)}`;
   if (column.required) str += '!';
   return str;
 }
 
+// turns a referenced tables into a line in the GraphQL object definition
+function mapConnection(connection) {
+  const connectedObj = capitalizeFirstLetter(singular(connection));
+  return `${connection}: [${connectedObj}]`;
+}
+
+// highest level function that takes a list of tables and their connections
+// returns the graphQL TypeDefs 
 function generateAllTypes(tables) {
-  let allTypes = ``;
-  tables.forEach((table) => {
-    allTypes += tableToType(table) + '\n\n';
+  let allTypes = `TypeDefs = \` \n`;
+  const [baseTables, joinTables] = sortTables(tables);
+  const joinTables = findJoinTables(tables);
+  const tablesToType = tables.filter((table) => {
+    return !Object.keys(joinTables).includes(table.name)
   });
-  return allTypes;
+  const allJoinConnections = mapJoinConnections(joinTables);
+  tablesToType.forEach((table) => {
+    allTypes += tableToType(table, allJoinConnections[table.name]) + '\n\n';
+  });
+  return allTypes + `\``;
 }
 
 module.exports = generateAllTypes;

--- a/converters/helpers.js
+++ b/converters/helpers.js
@@ -17,6 +17,45 @@ module.exports = {
 
   capitalizeFirstLetter: (string) => {
     return string[0].toUpperCase() + string.slice(1);
+  },
+
+  // function to identify which tables are join tables 
+  // assumes that a join table will be made up entirely of connections 
+    // aside from the primary key of the table
+  findJoinTables: (tables) => {
+    return tables.reduce((joinTables, table) => {
+      if (table.columns.length - table.connections.length <= 1) {
+        joinTables[table.name] = table.connections.map((conn) => {
+          return conn.destinationTable;
+        })
+      }
+      return joinTables;
+    }, {})
+  },
+
+  sortTables: (tables) => {
+    const baseTables = [];
+    const joinTables = [];
+    tables.forEach((table) => {
+      if (table.columns.length - tables.connections.length <= 1) {
+        joinTables.push(table);
+      } else {
+        baseTables.push(table);
+      }
+    })
+    return [baseTables, joinTables];
+  }
+
+  mapJoinConnections: (joinTables) => {
+    return Object.keys(joinTables).reduce((connections, currTable) => {
+      joinTables[currTable].forEach((ele, idx) => {
+        if (!connections[ele]) connections[ele] = [];
+        const connectedTables = joinTables[currTable].slice()
+        connectedTables.splice(idx,1);
+        connections[ele].push(...connectedTables);
+      })
+      return connections;
+    }, {})
   }
 
 }

--- a/converters/helpers.js
+++ b/converters/helpers.js
@@ -19,43 +19,33 @@ module.exports = {
     return string[0].toUpperCase() + string.slice(1);
   },
 
-  // function to identify which tables are join tables 
-  // assumes that a join table will be made up entirely of connections 
-    // aside from the primary key of the table
-  findJoinTables: (tables) => {
-    return tables.reduce((joinTables, table) => {
-      if (table.columns.length - table.connections.length <= 1) {
-        joinTables[table.name] = table.connections.map((conn) => {
-          return conn.destinationTable;
-        })
-      }
-      return joinTables;
-    }, {})
-  },
-
+  // sorts tables into two categories: base tables and join tables
+  // join tables are defined as those which are made up of foreign keys (except for the primary key)
   sortTables: (tables) => {
     const baseTables = [];
     const joinTables = [];
     tables.forEach((table) => {
-      if (table.columns.length - tables.connections.length <= 1) {
+      if (table.columns.length - table.connections.length <= 1) {
         joinTables.push(table);
       } else {
         baseTables.push(table);
       }
     })
     return [baseTables, joinTables];
-  }
+  },
 
-  mapJoinConnections: (joinTables) => {
-    return Object.keys(joinTables).reduce((connections, currTable) => {
-      joinTables[currTable].forEach((ele, idx) => {
-        if (!connections[ele]) connections[ele] = [];
-        const connectedTables = joinTables[currTable].slice()
-        connectedTables.splice(idx,1);
-        connections[ele].push(...connectedTables);
+  // takes an array of join tables and determines the connections between base tables
+  joinConnections: (joinTables) => {
+    const connections = {}
+    joinTables.forEach((joinTable) => {
+      joinTable.connections.forEach((conn, idx, arr) => {
+        const connectedTable = conn.destinationTable
+        if (!connections[connectedTable]) connections[connectedTable] = [];
+        const otherTables = arr.slice();
+        otherTables.splice(idx,1);
+        connections[connectedTable].push(...otherTables.map((table) => table.destinationTable));
       })
-      return connections;
-    }, {})
+    })
+    return connections;
   }
-
 }


### PR DESCRIPTION
**Issue:** Our code to generate TypeDefs only considered the columns in the table itself. It did not consider related base tables or join tables.

***In this PR:***

**In `helpers.js`:**
- Added helper function `sortTables` which sorts tables into two buckets: join tables and base tables 
- Added helper function `joinConnections` which takes a list of join tables and generates an object with a key for each base table that includes foreign keys. The value of each key is an array of tables for which that base table has a foreign key

**In `TypeDefs.js`:**
- Added `mapConnection` function to TypeDefs.js which takes a base table name and creates a line of code for a GQL object type definition
- Added logic to `tableToType` to include foreign key relationships as well as join table relationships to GQL object types
- Added logic to `generateAllTypes` to sort between join and base tables (using `sortTables`), generate find join table relationships (using `joinConnections`), create types for base tables only, and pass join table relationships into tableToType to be included in the type definition.