### PR TITLE
Refactored IDE and useEffect changes

### DIFF
--- a/components/Column.js
+++ b/components/Column.js
@@ -10,7 +10,7 @@ const Column = (props) => {
     useEffect(() => {
         
         if (!store.selectedElements)
-            return;
+            return populateEdges([]);
 
         populateEdges(props.selectedEdges([store.selectedElements[0]], store.edges));
         

--- a/components/DefaultInspector.js
+++ b/components/DefaultInspector.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useStoreState } from 'react-flow-renderer';
+import { useStoreState, useStoreActions } from 'react-flow-renderer';
 
 const DefaultInspector = (props) => {
 
@@ -12,6 +12,8 @@ const DefaultInspector = (props) => {
         setNodes(store.elements.filter(node => !node.id.includes('reactflow')));
     }, [store.elements]);
 
+    const setSelectedElements = useStoreActions((actions) => actions.setSelectedElements);
+
     const colors=['#ff6b6b', '#f9844aff', '#fee440', '#02c39a', '#4361ee', '#9b5de5', '#f15bb5'];
 
     return (
@@ -19,7 +21,7 @@ const DefaultInspector = (props) => {
 
             <button className='inspectorbtn' onClick={()=>showTable(!expand)} style={{transform: `${expand ? '' : 'translateX(313px)' }`}} >{expand ? '<' : '>'}</button>
 
-            {allNodes.map(node => <div className='tablename' onClick={()=>props.selectNode(node)} style={{borderLeft: `8px solid ${colors[node.id % colors.length]}`}} >{node.data.label.props.children.props.tablename}</div>)}
+            {allNodes.map((node, i) => <div className='tablename' key={`defaultnode#${i}`} onClick={()=>(setSelectedElements(node), props.selectNode(node))} style={{borderLeft: `8px solid ${colors[node.id % colors.length]}`}} >{node.data.label.props.children.props.tablename}</div>)}
 
             <style jsx>{`
 

--- a/components/DefaultInspector.js
+++ b/components/DefaultInspector.js
@@ -42,18 +42,19 @@ const DefaultInspector = (props) => {
                     font-family: 'Inter', sans-serif;
                     position: fixed;
                     padding: 4px 8px;
-                    // border-top-right-radius: 8px;
                     border-bottom-right-radius: 8px;
                     margin-left: 23%;
                     margin-top: 0;
-                    background-color: #e4eaf1;
+                    color: #6f8195;
+                    background-color: #d8e3e8;
                     border: none;
                     outline: none;
                     cursor: pointer;
                     z-index: 9999999999;
 
                     &:hover{
-                        background-color: #ababab;
+                        color: #12b3ab;
+                        background-color: #cad5e0;
                     }
                 }
 

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,24 +1,25 @@
 import Link from 'next/link';
 import { useState, useEffect } from 'react';
+import { useStoreState, useStoreActions } from 'react-flow-renderer';
 
 const Navbar = (props) => {
 
+    const store = useStoreState((store) => store);
+
     const [searchquery, typeSearch] = useState('');
+    const setSelectedElements = useStoreActions((actions) => actions.setSelectedElements);
 
-    useEffect(() => {
+    const submit = (e) => {
+        if (e.code === 'Enter' && searchquery.length > 0) {
+            e.target.blur();
 
-        const onKeyDown = ({key}) => {
-            if (key === "Enter" && searchquery.length > 0)
-                return (props.search(searchquery.toLowerCase()), typeSearch(''));
+            const target = store.elements.filter(node => !node.id.includes('reactflow')).findIndex(node => node.data.label.props.children.props.tablename === searchquery.toLowerCase());
+
+            if (target !== -1)
+                return (props.search(store.elements[target]), setSelectedElements(store.elements[target]), typeSearch(''));
+            else return typeSearch('');
         }
-
-        document.addEventListener('keydown', onKeyDown);
-
-        return () => {
-            document.removeEventListener('keydown', onKeyDown);
-        }
-
-    });
+    }
 
     return (
         <div id='navbar'>
@@ -28,7 +29,7 @@ const Navbar = (props) => {
             </Link>
             <h2>Codesmith NY 23</h2>
 
-            <input value={searchquery} placeholder='Search for a table name . . .' onChange={(e)=>typeSearch(e.target.value)} />
+            <input value={searchquery} placeholder='Search for a table name . . .' onChange={(e)=>typeSearch(e.target.value)} onKeyDown={submit} />
 
             <style jsx>{`
 

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useState, useEffect } from 'react';
 
 const Navbar = (props) => {
@@ -22,7 +23,9 @@ const Navbar = (props) => {
     return (
         <div id='navbar'>
 
-            <h1>GraphitiQL</h1>
+            <Link href='/'>
+                <h1>GraphitiQL</h1>
+            </Link>
             <h2>Codesmith NY 23</h2>
 
             <input value={searchquery} placeholder='Search for a table name . . .' onChange={(e)=>typeSearch(e.target.value)} />
@@ -39,6 +42,12 @@ const Navbar = (props) => {
                 h1 {
                     font-size: 16px;
                     color: #edf2f7;
+                    border-radius: 8px;
+                    padding: 8px;
+
+                    &:hover{
+                        background-color: #5f81e7;
+                    }
                 }
 
                 h2 {
@@ -55,6 +64,7 @@ const Navbar = (props) => {
                     position: fixed;
                     top: 0;
                     width: 100%;
+                    height: 39px;
                     padding: 8px;
                     z-index: 9999999999999999999999999;
                 }

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useStoreState, useStoreActions } from 'react-flow-renderer';
 
 const Navbar = (props) => {

--- a/components/Node.js
+++ b/components/Node.js
@@ -22,7 +22,6 @@ export default memo(({ data }) => {
     //Populate the edges array on first render, and every time our edges change
     useEffect(() => {
         populateEdges(props.selectedEdges([store.elements[props.nodeid]], store.edges));
-        console.log(store);
     }, [store.edges.length]);
 
     //useEffect #2 on [selectedElements]:

--- a/components/Node.js
+++ b/components/Node.js
@@ -35,17 +35,16 @@ export default memo(({ data }) => {
         if (!store.selectedElements)
             return;
 
-        if (store.selectedElements[0].id != props.nodeid.toString() && !selected)
+        if (store.selectedElements[0].id !== props.nodeid.toString() && !selected)
             return;
 
         if (store.selectedElements[0].id === props.nodeid.toString() && !selected){
-
             selectNode(true);
             showTable(true);
-
+            return;
         }
         else if (store.selectedElements[0].id !== props.nodeid.toString() && selected)
-            deselect();
+            return deselect();
 
     }, [store.selectedElements]);
 
@@ -57,11 +56,12 @@ export default memo(({ data }) => {
         if (!selected)
             return;
 
-        edges.forEach(edge => edge.source === props.nodeid.toString() ? edge.style = { stroke: 'rgba(3, 115, 252, 1)', strokeWidth: '5px' } : edge.style = { stroke: 'rgba(255, 107, 107, 1)', strokeWidth: '5px' });
+            edges.forEach(edge => edge.source === props.nodeid.toString() ? edge.style = { stroke: 'rgba(3, 115, 252, 1)', strokeWidth: '5px' } : edge.style = { stroke: 'rgba(255, 107, 107, 1)', strokeWidth: '5px' });
 
     }, [selected])
 
     const deselect = () => {
+
         selectNode(false);
 
         edges.forEach(edge => {

--- a/components/Node.js
+++ b/components/Node.js
@@ -29,6 +29,9 @@ export default memo(({ data }) => {
     //If they match, this becomes the selected node.
     useEffect(() => {
 
+        if (!store.selectedElements && selected)
+            deselect();
+            
         if (!store.selectedElements)
             return;
 
@@ -41,15 +44,8 @@ export default memo(({ data }) => {
             showTable(true);
 
         }
-        else if (store.selectedElements[0].id !== props.nodeid.toString() && selected){
-            
-            selectNode(false);
-
-            edges.forEach(edge => {
-                edge.style = { stroke: 'rgba(3, 115, 252, .75)', strokeWidth: '1px' };
-            });
-
-        }
+        else if (store.selectedElements[0].id !== props.nodeid.toString() && selected)
+            deselect();
 
     }, [store.selectedElements]);
 
@@ -64,6 +60,14 @@ export default memo(({ data }) => {
         edges.forEach(edge => edge.source === props.nodeid.toString() ? edge.style = { stroke: 'rgba(3, 115, 252, 1)', strokeWidth: '5px' } : edge.style = { stroke: 'rgba(255, 107, 107, 1)', strokeWidth: '5px' });
 
     }, [selected])
+
+    const deselect = () => {
+        selectNode(false);
+
+        edges.forEach(edge => {
+            edge.style = { stroke: 'rgba(3, 115, 252, .75)', strokeWidth: '1px' };
+        });
+    }
 
     //Array of possible header colors
     //TOOD: Expand, make editable

--- a/components/Node.js
+++ b/components/Node.js
@@ -22,7 +22,8 @@ export default memo(({ data }) => {
     //Populate the edges array on first render, and every time our edges change
     useEffect(() => {
         populateEdges(props.selectedEdges([store.elements[props.nodeid]], store.edges));
-    }, [store.edges]);
+        console.log(store);
+    }, [store.edges.length]);
 
     //useEffect #2 on [selectedElements]:
     //Checks the selectedElement's id against this node's id

--- a/components/NodeInspector.js
+++ b/components/NodeInspector.js
@@ -129,18 +129,19 @@ const NodeInspector = (data) =>{
                     font-family: 'Inter', sans-serif;
                     position: fixed;
                     padding: 4px 8px;
-                    // border-top-right-radius: 8px;
                     border-bottom-right-radius: 8px;
                     margin-left: 23%;
                     margin-top: 0;
-                    background-color: #e4eaf1;
+                    color: #6f8195;
+                    background-color: #d8e3e8;
                     border: none;
                     outline: none;
                     cursor: pointer;
                     z-index: 9999999999;
 
                     &:hover{
-                        background-color: #ababab;
+                        color: #12b3ab;
+                        background-color: #cad5e0;
                     }
                 }
 

--- a/components/NodeInspector.js
+++ b/components/NodeInspector.js
@@ -20,9 +20,7 @@ const NodeInspector = (data) =>{
 
     //When the data (props) as activeNode being sent to the inspector change, we update the activeNode state
     useEffect(()=>{
-
         updateNode(data.data);
-
     }, [data]);
 
     useEffect(() => {
@@ -65,7 +63,7 @@ const NodeInspector = (data) =>{
             <div className='sidebar' >
 
                 {/* Edit Button */}
-                <div onClick={()=>{editable ? savechanges() : toggleEdit(!editable)}} ><Pencil editable={editable ? true : undefined} /></div>
+                <div onClick={()=>{editable ? savechanges() : toggleEdit(!editable)}} ><Pencil editable={editable ? 1 : undefined} /></div>
 
                 {/* Tablename */}
                 <div className='tablename' style={{borderLeft: `8px solid ${colors[props.nodeid % colors.length]}`, backgroundColor: `${editable ? '#c0dbfd' : 'white'}`}} >

--- a/components/NodeInspector.js
+++ b/components/NodeInspector.js
@@ -18,21 +18,6 @@ const NodeInspector = (data) =>{
     //We make an exact copy of our currently activeNode in our state
     const [activeNode, updateNode] = useState(data.data);
 
-    useEffect(() => {
-
-        const onKeyDown = ({key}) => {
-            if (key === "Enter" && editable)
-                return submit();
-        }
-
-        document.addEventListener('keydown', onKeyDown);
-
-        return () => {
-            document.removeEventListener('keydown', onKeyDown);
-        }
-
-    });
-
     //When the data (props) as activeNode being sent to the inspector change, we update the activeNode state
     useEffect(()=>{
 
@@ -59,21 +44,28 @@ const NodeInspector = (data) =>{
 
     }, [tableName]);
 
-    const submit = () => {
+    const submit = (e) => {
+
+        if (e.code === "Enter" && editable)
+            return savechanges();
+
+    }
+
+    const savechanges = () => {
         return (toggleEdit(false), data.nodeValueChange(activeNode));
     }
 
     const colors=['#ff6b6b', '#f9844aff', '#fee440', '#02c39a', '#4361ee', '#9b5de5', '#f15bb5'];
 
     return (
-        <div className='inspector' style={{transform: `${expand ? '' : 'translateX(-360px)' }`, position: `${expand ? 'fixed' : 'fixed'}`}} >
+        <div className='inspector' style={{transform: `${expand ? '' : 'translateX(-360px)' }`, position: `${expand ? 'fixed' : 'fixed'}`}} onKeyDown={submit} >
 
             <button className='inspectorbtn' onClick={()=>showTable(!expand)} style={{transform: `${expand ? '' : 'translateX(278px)' }`}} >{expand ? '<' : '>'}</button>
 
             <div className='sidebar' >
 
                 {/* Edit Button */}
-                <div onClick={()=>{editable ? submit() : toggleEdit(!editable)}} ><Pencil edit={editable} /></div>
+                <div onClick={()=>{editable ? savechanges() : toggleEdit(!editable)}} ><Pencil editable={editable ? true : undefined} /></div>
 
                 {/* Tablename */}
                 <div className='tablename' style={{borderLeft: `8px solid ${colors[props.nodeid % colors.length]}`, backgroundColor: `${editable ? '#c0dbfd' : 'white'}`}} >

--- a/components/SchemaIDE.js
+++ b/components/SchemaIDE.js
@@ -20,7 +20,10 @@ const SchemaIDE = (props) => {
     }, []);
 
     useEffect(() => {
-        
+
+        if (!props.updated)
+            return;
+
         const newTables = [];
 
         store.elements.filter(node => !node.id.includes('reactflow')).forEach(node => {
@@ -36,14 +39,18 @@ const SchemaIDE = (props) => {
 
         updateTable(newTables);
 
-    }, [store.elements]);
+    }, [props.updated]);
 
     useEffect(() => {
         refreshSchema();
+        props.resetUpdate(false);
     }, [tables]);
 
-    const refreshSchema = () => {
+    useEffect(() => {
         hljs.initHighlighting();
+    }, [schema]);
+
+    const refreshSchema = () => {
         writeSchema(generateAllTypes(tables));
     }
 
@@ -59,6 +66,8 @@ const SchemaIDE = (props) => {
     }
     `
 
+    const holder = schema.toString();
+
     return (
         <div id='ide' >
 
@@ -66,110 +75,7 @@ const SchemaIDE = (props) => {
 
                 <div id='gql'><h1>GraphQL</h1><h2>Query</h2></div>
 
-                <pre><code>{`
-type Film { 
-    director: String!
-    opening_crawl: String!
-    episode_id: Int!
-    _id: Int!
-    title: String!
-    release_date: Int!
-    producer: String!
-}
-
-type Person { 
-    gender: String
-    species_id: Int
-    homeworld_id: Int
-    height: Int
-    _id: Int!
-    mass: String
-    hair_color: String
-    skin_color: String
-    eye_color: String
-    name: String!
-    birth_year: String
-}
-
-type People_in_film { 
-    person_id: Int!
-    film_id: Int!
-    _id: Int!
-}
-
-type Pilot { 
-    _id: Int!
-    person_id: Int!
-    vessel_id: Int!
-}
-
-type Planet { 
-    orbital_period: Int
-    climate: String
-    gravity: String
-    terrain: String
-    surface_water: String
-    population: Int
-    _id: Int!
-    name: String
-    rotation_period: Int
-    diameter: Int
-}
-
-type Planets_in_film { 
-    film_id: Int!
-    planet_id: Int!
-    _id: Int!
-}
-
-type Species { 
-    hair_colors: String
-    name: String!
-    classification: String
-    average_height: String
-    average_lifespan: String
-    skin_colors: String
-    eye_colors: String
-    language: String
-    homeworld_id: Int
-    _id: Int!
-}
-
-type Species_in_film { 
-    film_id: Int!
-    species_id: Int!
-    _id: Int!
-}
-
-type Starship_spec { 
-    _id: Int!
-    vessel_id: Int!
-    MGLT: String
-    hyperdrive_rating: String
-}
-
-type Vessel { 
-    cost_in_credits: Int
-    length: String
-    vessel_type: String!
-    model: String
-    manufacturer: String
-    name: String!
-    vessel_class: String!
-    max_atmosphering_speed: String
-    crew: Int
-    passengers: Int
-    cargo_capacity: String
-    consumables: String
-    _id: Int!
-}
-
-type Vessels_in_film { 
-    _id: Int!
-    film_id: Int!
-    vessel_id: Int!
-}
-                `}</code></pre>
+                <pre><code>{holder}</code></pre>
 
             </div>
 

--- a/components/SchemaIDE.js
+++ b/components/SchemaIDE.js
@@ -21,8 +21,8 @@ const SchemaIDE = (props) => {
 
     useEffect(() => {
 
-        if (!props.updated)
-            return;
+        // if (!props.updated)
+        //     return;
 
         const newTables = [];
 
@@ -32,6 +32,7 @@ const SchemaIDE = (props) => {
 
             newTable.name = node.data.label.props.children.props.tablename;
             newTable.columns = node.data.label.props.children.props.columns;
+            newTable.connections = [];
 
             newTables.push(newTable);
 

--- a/components/icons/Pencil.js
+++ b/components/icons/Pencil.js
@@ -18,7 +18,7 @@ const Pencil = (props) => {
             />
         </svg>
 
-        <h1 style={{transform: `${props.editable ? 'translateX(-28px)' : 'translateX(0px)'}`}}>{props.editable ? 'Submit' : 'Edit'}</h1>
+        <h1 style={{transform: `${props.editable === 1 ? 'translateX(-28px)' : 'translateX(0px)'}`}}>{props.editable === 1 ? 'Submit' : 'Edit'}</h1>
 
         <style jsx>{`
 

--- a/components/icons/Pencil.js
+++ b/components/icons/Pencil.js
@@ -18,7 +18,7 @@ const Pencil = (props) => {
             />
         </svg>
 
-        <h1 style={{transform: `${props.edit ? 'translateX(-28px)' : 'translateX(0px)'}`}}>{props.edit ? 'Submit' : 'Edit'}</h1>
+        <h1 style={{transform: `${props.editable ? 'translateX(-28px)' : 'translateX(0px)'}`}}>{props.editable ? 'Submit' : 'Edit'}</h1>
 
         <style jsx>{`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -971,17 +971,6 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
-    "clipboard": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
-      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -1556,12 +1545,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -2166,15 +2149,6 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
-      }
-    },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
       }
     },
     "got": {
@@ -3920,14 +3894,6 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
-    "prismjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -4388,12 +4354,6 @@
           }
         }
       }
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true
     },
     "semver": {
       "version": "6.3.0",
@@ -4965,12 +4925,6 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
-    },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "next": "^10.0.6",
     "pg": "^8.5.1",
     "pluralize": "^8.0.0",
-    "prismjs": "^1.23.0",
     "react": "^17.0.1",
     "react-dom": "17.0.1",
     "react-flow-renderer": "^8.7.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,10 @@
+import { ReactFlowProvider }  from 'react-flow-renderer';
+
 import '../styles/globals.css'
 import 'highlight.js/styles/an-old-hope.css';
 
 const MyApp = ({ Component, pageProps }) => {
-  return <Component {...pageProps} />
+  return <ReactFlowProvider><Component {...pageProps} /></ReactFlowProvider>
 }
 
 export default MyApp

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,8 @@
-import { ReactFlowProvider }  from 'react-flow-renderer';
-
 import '../styles/globals.css'
 import 'highlight.js/styles/an-old-hope.css';
 
 const MyApp = ({ Component, pageProps }) => {
-  return <ReactFlowProvider><Component {...pageProps} /></ReactFlowProvider>
+  return <Component {...pageProps} />
 }
 
 export default MyApp

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -45,14 +45,6 @@ const Canvas = (props) => {
     cacheInstance(reactFlowInstance);
   };  
 
-  const searchNode = (tablename) => {
-    
-    const target = elements.filter(node => !node.id.includes('reactflow')).findIndex(node => node.data.label.props.children.props.tablename === tablename);
-
-    if (target !== -1)
-      selectNode(elements[target]);
-  }
-
   useEffect(() => {
 
     if (!instance)
@@ -127,9 +119,9 @@ const Canvas = (props) => {
 
   const onPaneClick = () => selectNode(null);
 
-  const onElementClick = (event, element) => {if (isNode(element)) selectNode(element)};
+  const onElementClick = (event, element) => {if (isNode(element)) return selectNode(element)};
   const onNodeDragStart = (event, node) => selectNode(node);
-  const selectedEdges = (node, edges) => getConnectedEdges(node, edges);
+  const selectedEdges = (node, edges) => {if (node) return getConnectedEdges(node, edges)};
   const nodeValueChange = (node) => {
 
     if(!node.data.label.props.children.props.selectedEdges)
@@ -218,13 +210,12 @@ const Canvas = (props) => {
   return (
     <div id='root'>
 
-      <Navbar search={searchNode} />
-
       <div id='canvascontainer'>
             
         {/*We set up a component to hold our ReactFlow (the component that holds the methods/functionality of and renders our react-flow)*/}
         {/*Here's where we can set any properties and add custom methods to be accessible throughout the rest of the app*/}
         <ReactFlowProvider>
+          <Navbar search={selectNode} />
           {inspector}
           <ReactFlow
               //default zoom properties

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -1,6 +1,5 @@
 //🦒
-import ReactFlow, { removeElements, getConnectedEdges, isNode, useStoreState, useStoreActions }  from 'react-flow-renderer';
-
+import ReactFlow, { removeElements, ReactFlowProvider, getConnectedEdges, isNode}  from 'react-flow-renderer';
 import { useState, useEffect } from 'react'
 
 import dagre from 'dagre';
@@ -25,8 +24,6 @@ const dagreGraph = new dagre.graphlib.Graph();
 dagreGraph.setDefaultEdgeLabel(() => ({}));
 
 const Canvas = (props) => {
-
-  const store = useStoreState((store) => store);
 
   //Our main React Hook state that holds the data of every element (node, connection) that gets rendered onto the page
   //NOTE: When rerendered, all of the existing nodes will have their state reset. This includes expand/collapse state.
@@ -128,14 +125,11 @@ const Canvas = (props) => {
     setElements(els => els.concat([connection]));
   };
 
-  const onPaneClick = () => (selectNode(null), setSelectedElements([]));
+  const onPaneClick = () => selectNode(null);
 
   const onElementClick = (event, element) => {if (isNode(element)) selectNode(element)};
   const onNodeDragStart = (event, node) => selectNode(node);
-
-  const setSelectedElements = useStoreActions((actions) => actions.setSelectedElements);
   const selectedEdges = (node, edges) => getConnectedEdges(node, edges);
-
   const nodeValueChange = (node) => {
 
     if(!node.data.label.props.children.props.selectedEdges)
@@ -230,40 +224,42 @@ const Canvas = (props) => {
             
         {/*We set up a component to hold our ReactFlow (the component that holds the methods/functionality of and renders our react-flow)*/}
         {/*Here's where we can set any properties and add custom methods to be accessible throughout the rest of the app*/}
-        {inspector}
-        <ReactFlow
-            //default zoom properties
-            minZoom={0.1}
-            maxZoom={.75}
-            defaultZoom={.4}
-            zoomOnScroll={zoomOnScroll}
-            zoomOnDoubleClick={zoomOnDoubleClick}
+        <ReactFlowProvider>
+          {inspector}
+          <ReactFlow
+              //default zoom properties
+              minZoom={0.1}
+              maxZoom={.75}
+              defaultZoom={.4}
+              zoomOnScroll={zoomOnScroll}
+              zoomOnDoubleClick={zoomOnDoubleClick}
 
-            //Element removal callback
-            onElementsRemove={onElementsRemove}
+              //Element removal callback
+              onElementsRemove={onElementsRemove}
 
-            //Element connect, click, drag callbacks/listeners
-            onConnect={onConnect}
-            onElementClick={onElementClick}
-            onNodeDragStart={onNodeDragStart}
+              //Element connect, click, drag callbacks/listeners
+              onConnect={onConnect}
+              onElementClick={onElementClick}
+              onNodeDragStart={onNodeDragStart}
 
-            onLoad={onLoad}
-            onPaneClick={onPaneClick}
-            
-            //Assigning our custom types to be rendered
-            nodeTypes={nodeTypes}
-            elements={elements}
-            style={graphStyles}
+              onLoad={onLoad}
+              onPaneClick={onPaneClick}
+              
+              //Assigning our custom types to be rendered
+              nodeTypes={nodeTypes}
+              elements={elements}
+              style={graphStyles}
 
-            // connectionLineType={'step'}
-            connectionLineStyle={connectionStyles}
-            >
-            {/* Bottom-left UI zoom and fit screen controls */}
-            {/*<Controls style={{zIndex: '999999999', marginBottom: '8px', marginLeft: '96.5vw', position: 'fixed'}} />*/}
-            {/* Background pattern, can be lines or dots */}
+              // connectionLineType={'step'}
+              connectionLineStyle={connectionStyles}
+              >
+              {/* Bottom-left UI zoom and fit screen controls */}
+              {/*<Controls style={{zIndex: '999999999', marginBottom: '8px', marginLeft: '96.5vw', position: 'fixed'}} />*/}
+              {/* Background pattern, can be lines or dots */}
 
-        </ReactFlow>
-        <SchemaIDE />
+          </ReactFlow>
+          <SchemaIDE />
+        </ReactFlowProvider>
 
       </div>
 

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -143,6 +143,8 @@ const Canvas = (props) => {
   useEffect(() => {
 
     const newElements = [];
+
+    console.log(props.data.tables[1].connections);
    
     for (let i = 0; i < props.data.tables.length; i++){
 
@@ -207,6 +209,8 @@ const Canvas = (props) => {
     //NOTE: we must either always REPLACE the elements array, or ensure we are adding to the array without overlapping id's
     setElements([...newElements]);
     setNodeCount(props.data.tables.length);
+
+    updateData(true);
 
   }, []);
 

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -30,7 +30,9 @@ const Canvas = (props) => {
   //TODO: Unbundle/refactor state out of Nodes or find way to memoize data on re-render.
   const [elements, setElements] = useState([]);
   const [index, setNodeCount] = useState(0);
+
   const [layedout, toggleLayout] = useState(false);
+  const [updated, updateData] = useState(false);
 
   const [instance, cacheInstance] = useState(null);
 
@@ -49,7 +51,7 @@ const Canvas = (props) => {
 
     if (!instance)
       return;
-
+    
     instance.fitView();
     instance.zoomTo(.4);
     
@@ -119,8 +121,8 @@ const Canvas = (props) => {
 
   const onPaneClick = () => selectNode(null);
 
-  const onElementClick = (event, element) => {if (isNode(element)) return selectNode(element)};
-  const onNodeDragStart = (event, node) => selectNode(node);
+  const onElementClick = (event, element) => {if (isNode(element) && element !== activeNode) return selectNode(element)};
+  const onNodeDragStart = (event, node) => {if (node !== activeNode) return selectNode(node)};
   const selectedEdges = (node, edges) => {if (node) return getConnectedEdges(node, edges)};
   const nodeValueChange = (node) => {
 
@@ -132,6 +134,9 @@ const Canvas = (props) => {
 
     newElements.splice(target, 1, node);
     setElements(newElements);
+
+    updateData(true);
+    
   };
 
   //Runs only once when this page renders
@@ -153,7 +158,7 @@ const Canvas = (props) => {
           //In the case of our nodes, we pass in a Node.js component with all of the props from the associated table data index.
           label: (
             <div>
-              <Node id={`${props.data.tables[i].name}column#${i}`} key={`${props.data.tables[i].name}column#${i}`} nodeid={i} tablename={props.data.tables[i].name} columns={props.data.tables[i].columns} selectedEdges={selectedEdges} />
+              <div id={`${props.data.tables[i].name}column#${i}`} key={`${props.data.tables[i].name}column#${i}`} nodeid={i} tablename={props.data.tables[i].name} columns={props.data.tables[i].columns} selectedEdges={selectedEdges} />
             </div>
             ),
           },
@@ -249,7 +254,7 @@ const Canvas = (props) => {
               {/* Background pattern, can be lines or dots */}
 
           </ReactFlow>
-          <SchemaIDE />
+          <SchemaIDE updated={updated} resetUpdate={updateData} />
         </ReactFlowProvider>
 
       </div>

--- a/pages/canvas.js
+++ b/pages/canvas.js
@@ -1,5 +1,6 @@
 //🦒
-import ReactFlow, { Controls, removeElements, ReactFlowProvider, getConnectedEdges, isNode}  from 'react-flow-renderer';
+import ReactFlow, { removeElements, getConnectedEdges, isNode, useStoreState, useStoreActions }  from 'react-flow-renderer';
+
 import { useState, useEffect } from 'react'
 
 import dagre from 'dagre';
@@ -25,6 +26,8 @@ dagreGraph.setDefaultEdgeLabel(() => ({}));
 
 const Canvas = (props) => {
 
+  const store = useStoreState((store) => store);
+
   //Our main React Hook state that holds the data of every element (node, connection) that gets rendered onto the page
   //NOTE: When rerendered, all of the existing nodes will have their state reset. This includes expand/collapse state.
   //TODO: Unbundle/refactor state out of Nodes or find way to memoize data on re-render.
@@ -42,7 +45,6 @@ const Canvas = (props) => {
   const [activeNode, selectNode] = useState(null);
 
   const onLoad = (reactFlowInstance) => {
-    reactFlowInstance.zoomTo(.3);
     cacheInstance(reactFlowInstance);
   };  
 
@@ -125,9 +127,15 @@ const Canvas = (props) => {
     
     setElements(els => els.concat([connection]));
   };
+
+  const onPaneClick = () => (selectNode(null), setSelectedElements([]));
+
   const onElementClick = (event, element) => {if (isNode(element)) selectNode(element)};
   const onNodeDragStart = (event, node) => selectNode(node);
+
+  const setSelectedElements = useStoreActions((actions) => actions.setSelectedElements);
   const selectedEdges = (node, edges) => getConnectedEdges(node, edges);
+
   const nodeValueChange = (node) => {
 
     if(!node.data.label.props.children.props.selectedEdges)
@@ -222,41 +230,40 @@ const Canvas = (props) => {
             
         {/*We set up a component to hold our ReactFlow (the component that holds the methods/functionality of and renders our react-flow)*/}
         {/*Here's where we can set any properties and add custom methods to be accessible throughout the rest of the app*/}
-        <ReactFlowProvider>
-          {inspector}
-          <ReactFlow
-              //default zoom properties
-              minZoom={0.1}
-              maxZoom={.75}
-              defaultZoom={.4}
-              zoomOnScroll={zoomOnScroll}
-              zoomOnDoubleClick={zoomOnDoubleClick}
+        {inspector}
+        <ReactFlow
+            //default zoom properties
+            minZoom={0.1}
+            maxZoom={.75}
+            defaultZoom={.4}
+            zoomOnScroll={zoomOnScroll}
+            zoomOnDoubleClick={zoomOnDoubleClick}
 
-              //Element removal callback
-              onElementsRemove={onElementsRemove}
+            //Element removal callback
+            onElementsRemove={onElementsRemove}
 
-              //Element connect, click, drag callbacks/listeners
-              onConnect={onConnect}
-              onElementClick={onElementClick}
-              onNodeDragStart={onNodeDragStart}
+            //Element connect, click, drag callbacks/listeners
+            onConnect={onConnect}
+            onElementClick={onElementClick}
+            onNodeDragStart={onNodeDragStart}
 
-              onLoad={onLoad}
-              
-              //Assigning our custom types to be rendered
-              nodeTypes={nodeTypes}
-              elements={elements}
-              style={graphStyles}
+            onLoad={onLoad}
+            onPaneClick={onPaneClick}
+            
+            //Assigning our custom types to be rendered
+            nodeTypes={nodeTypes}
+            elements={elements}
+            style={graphStyles}
 
-              // connectionLineType={'step'}
-              connectionLineStyle={connectionStyles}
-              >
-              {/* Bottom-left UI zoom and fit screen controls */}
-              {/*<Controls style={{zIndex: '999999999', marginBottom: '8px', marginLeft: '96.5vw', position: 'fixed'}} />*/}
-              {/* Background pattern, can be lines or dots */}
+            // connectionLineType={'step'}
+            connectionLineStyle={connectionStyles}
+            >
+            {/* Bottom-left UI zoom and fit screen controls */}
+            {/*<Controls style={{zIndex: '999999999', marginBottom: '8px', marginLeft: '96.5vw', position: 'fixed'}} />*/}
+            {/* Background pattern, can be lines or dots */}
 
-          </ReactFlow>
-          <SchemaIDE />
-        </ReactFlowProvider>
+        </ReactFlow>
+        <SchemaIDE />
 
       </div>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,5 @@
-import Link from 'next/link'
-import { useState, useEffect } from 'react'
-
-import Navbar from '../components/Navbar.js';
+import Link from 'next/link';
+import { useState, useEffect } from 'react';
 
 const Home = (props) => {
 


### PR DESCRIPTION
**Issue:**
-Excessive calls from improperly handled useEffect usage were slowing down the application.
-SchemaIDE does not accept account for node connections
-Users could not deselect nodes without deleting

**Solution:**
-Refactored all useEffects to call only as often as needed
-Added default inspector for when no nodes are selected, and allowed unselect by clicking in the node window
-Added search bar

**TODO:**
-Refactor canvas and nodes to remove activeNode and replace with built in store action for selected elements