### PR TITLE
Data type fix

### DIFF
--- a/converters/helpers.js
+++ b/converters/helpers.js
@@ -10,6 +10,8 @@ module.exports = {
         return "Float";
       case "date":
         return "Int";
+      case 'boolean': 
+        return 'Boolean'
       default:
         return "Unknown";
     }

--- a/converters/helpers.js
+++ b/converters/helpers.js
@@ -2,18 +2,18 @@
 module.exports = {
   convertDataType: (sqlDataType) => {
     switch (sqlDataType) {
-      case "character varying":
-        return "String";
-      case "integer":
-        return "Int";
-      case "bigint":
-        return "Float";
-      case "date":
-        return "Int";
+      case 'character varying':
+        return 'String';
+      case 'integer':
+        return 'Int';
+      case 'bigint':
+        return 'Float';
+      case 'date':
+        return 'Int';
       case 'boolean': 
         return 'Boolean'
       default:
-        return "Unknown";
+        return 'String';
     }
   },
 


### PR DESCRIPTION
**Issue:** We were mapping date types to integers which caused and error for timestamps since unix timestamp integers are too large for GraphQL to handle. 

**Fix:** 
- Set date fields to be Strings in GraphQL
- Also, we set the default datatype to be a String instead of "unknown" 


